### PR TITLE
fix lsp config for nvim > 0.11 and update config for mason to v2

### DIFF
--- a/lua/modules/lsp.lua
+++ b/lua/modules/lsp.lua
@@ -265,7 +265,8 @@ return {
 			require('mason-tool-installer').setup { ensure_installed = ensure_installed }
 
 			for server_name, server_config in pairs(servers) do
-				require('lspconfig')[server_name].setup(server_config)
+		        vim.lsp.config(server_name, server_config)
+		        vim.lsp.enable(server_name)
 			end
 		end,
 	},


### PR DESCRIPTION
Remove deprecated method `require('lspconfig')[server_name].setup(server_config)`.
Using new method:
```
vim.lsp.config(server_name, server_config)
vim.lsp.enable(server_name)
```

More information here: https://github.com/nvim-lua/kickstart.nvim/pull/1663